### PR TITLE
Solidity version changes

### DIFF
--- a/contracts/MagicSquare.sol
+++ b/contracts/MagicSquare.sol
@@ -1,4 +1,5 @@
-pragma solidity >=0.4.18;
+pragma solidity >=0.5.6;
+
 pragma experimental ABIEncoderV2;
 
 import "./SquareLib.sol";
@@ -27,7 +28,7 @@ contract MagicSquare {
       (x, y, i) = square.step(x, y, i);
     }
 
-    save(square);
+    this.save(square);
     storedGreeting = "finally, a decentralized magic square service!";
   }
 
@@ -40,7 +41,7 @@ contract MagicSquare {
   }
 
   function save(SquareLib.MagicSquare memory square)
-    internal
+    public
   {
     uint256 x;
     uint256 y;

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.17;
+pragma solidity >=0.5.6;
 
 contract Migrations {
   address public owner;

--- a/contracts/SquareLib.sol
+++ b/contracts/SquareLib.sol
@@ -1,4 +1,5 @@
-pragma solidity >=0.4.18;
+pragma solidity >=0.5.6;
+pragma experimental ABIEncoderV2;
 
 library SquareLib {
   struct MagicSquare {
@@ -7,7 +8,7 @@ library SquareLib {
   }
 
   function initialize(uint256 n)
-    internal
+    external
     pure
     returns (MagicSquare memory square)
   {

--- a/truffle.js
+++ b/truffle.js
@@ -5,5 +5,12 @@ module.exports = {
     solc: {
       version: "^0.5.7"
     }
+  },
+  networks: {
+    development: {
+    host: "127.0.0.1",
+    port: 8545,
+    network_id: "*" // Match any network id
+   }
   }
 };


### PR DESCRIPTION
The purpose of this PR is to upgrade the version of solidity being used so that, in turn, we can make the `SquareLib` `save()` function external. This is being done so that this project calls an external library and it's Bytecode therefore contains a link reference. 